### PR TITLE
Makefile ベンチマーク実行コマンドを修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ all: bench slow-query log-rotate
 # benchを実行
 .PHONY: bench
 bench:
-	cd $(APP_HOME)/bench && ./bench
+	cd $(APP_HOME)/bench && ./bench --target-url http://localhost:8080
 
 
 # slow-queryを解析し、テキストファイルに出力


### PR DESCRIPTION
## 背景
nginxのaccess_logが出力されなかった

## 原因
`./bench`を実行するとnginxを経由せずに直でAPIサーバーにリクエストが飛ぶようになってた

## 対応
`./bench --target-url http://localhost:8080`で実行し、nginxを経由するように修正